### PR TITLE
replace len check with nil for default opts

### DIFF
--- a/sphinx.go
+++ b/sphinx.go
@@ -230,7 +230,7 @@ var DefaultOptions = &Options{
 }
 
 func NewClient(opts ...*Options) (sc *Client) {
-	if len(opts) > 1 {
+	if opts != nil {
 		return &Client{Options: opts[0]}
 	}
 	return &Client{Options: DefaultOptions}


### PR DESCRIPTION
The len(opts) check was not working. 
This works well and is more idiomatic in my opinion.
