### PR TITLE
Multiple queries problems

### DIFF
--- a/sphinx.go
+++ b/sphinx.go
@@ -905,7 +905,7 @@ func (sc *Client) RunQueries() (results []Result, err error) {
 
 		results = append(results, result)
 	}
-
+	sc.reqs = nil
 	return
 }
 


### PR DESCRIPTION
There are 2 problems with the current implementation of multiple queries :
- errors are not returned
- queries are not reset between RunQueries call

AddQuery(q1)
AddQuery(q2)
RunQueries() // will run q1 and q2
AddQuery(q3)
RunQueries() // will run q1, q2 and q3
