### PR TITLE
SetDealine is not reset at the end of connect, it generates timeouts in future calls

### DIFF
--- a/sphinx.go
+++ b/sphinx.go
@@ -1299,6 +1299,8 @@ func (sc *Client) connect() (err error) {
 		return fmt.Errorf("connect() conn.Write() > %d bytes, %v", i, err)
 	}
 
+	sc.conn.SetDeadline(time.Time{})
+
 	return
 }
 


### PR DESCRIPTION
```
// A deadline is an absolute time after which I/O operations
// fail with a timeout (see type Error) instead of
// blocking. The deadline applies to all future I/O, not just
// the immediately following call to Read or Write.
```

The deadline needs to be reset at the end of connect.
